### PR TITLE
op_correction: support negative coefficients for CCM

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -430,6 +430,7 @@ static int cmd_correction(int argc, char **argv)
 {
 	union mpix_correction_any corr = {0};
 	unsigned long long ull;
+	long long ll;
 	uint32_t type;
 	char *arg;
 	int ret;
@@ -506,12 +507,12 @@ static int cmd_correction(int argc, char **argv)
 		for (int i = 2; i < 2 + 9; i++) {
 			arg = argv[i];
 
-			ull = strtof(arg, &arg) * (1 << MPIX_CORRECTION_SCALE_BITS);
-			if (*argv[i] == '\0' || *arg != '\0' || ull > UINT16_MAX) {
+			ll = strtof(arg, &arg) * (1 << MPIX_CORRECTION_SCALE_BITS);
+			if (*argv[i] == '\0' || *arg != '\0' || ll < INT16_MIN || ll > INT16_MAX) {
 				MPIX_ERR("Invalid CCM coefficient '%s'", argv[i]);
 				return -EINVAL;
 			}
-			corr.color_matrix.levels[i - 2] = ull;
+			corr.color_matrix.levels[i - 2] = ll;
 		}
 
 		break;

--- a/include/mpix/op_correction.h
+++ b/include/mpix/op_correction.h
@@ -32,7 +32,7 @@ struct mpix_correction_white_balance {
  */
 struct mpix_correction_color_matrix {
 	/** 3x3 array with values obtained by calibration */
-	uint16_t levels[9];
+	int16_t levels[9];
 };
 
 /**

--- a/src/op_correction.c
+++ b/src/op_correction.c
@@ -158,27 +158,27 @@ MPIX_REGISTER_CORRECTION_OP(gc_rgb24, mpix_correction_gamma_rgb24, GAMMA, RGB24)
 void mpix_correction_color_matrix_rgb24(const uint8_t *src, uint8_t *dst, uint16_t width,
 		                        uint16_t line_offset, union mpix_correction_any *corr)
 {
-	uint16_t *levels = corr->color_matrix.levels;
+	int16_t *levels = corr->color_matrix.levels;
 
 	for (size_t w = 0; w + 3 <= width; w++, dst += 3, src += 3) {
-		uint32_t r;
-		uint32_t g;
-		uint32_t b;
+		int32_t r;
+		int32_t g;
+		int32_t b;
 
 		r = src[0] * levels[0] >> MPIX_CORRECTION_SCALE_BITS;
 		g = src[1] * levels[1] >> MPIX_CORRECTION_SCALE_BITS;
 		b = src[2] * levels[2] >> MPIX_CORRECTION_SCALE_BITS;
-		dst[0] = MIN(r + g + b, 0xff);
+		dst[0] = CLAMP(r + g + b, 0x00, 0xff);
 
 		r = src[0] * levels[3] >> MPIX_CORRECTION_SCALE_BITS;
 		g = src[1] * levels[4] >> MPIX_CORRECTION_SCALE_BITS;
 		b = src[2] * levels[5] >> MPIX_CORRECTION_SCALE_BITS;
-		dst[1] = MIN(r + g + b, 0xff);
+		dst[1] = CLAMP(r + g + b, 0x00, 0xff);
 
 		r = src[0] * levels[6] >> MPIX_CORRECTION_SCALE_BITS;
 		g = src[1] * levels[7] >> MPIX_CORRECTION_SCALE_BITS;
 		b = src[2] * levels[8] >> MPIX_CORRECTION_SCALE_BITS;
-		dst[2] = MIN(r + g + b, 0xff);
+		dst[2] = CLAMP(r + g + b, 0x00, 0xff);
 	}
 }
 MPIX_REGISTER_CORRECTION_OP(ccm_rgb24, mpix_correction_color_matrix_rgb24, COLOR_MATRIX, RGB24);


### PR DESCRIPTION
Unlike white balance, color correction matrix can have negative coefficients.

This permits to select the main channel with a positive coefficient (such as 1.07 for red), and compensate the leak on the other color channels with a negative coefficient (such as 0.03 for green and 0.07 for blue).

Fixes #16